### PR TITLE
Define method by braces

### DIFF
--- a/lib/java/java_class.rb
+++ b/lib/java/java_class.rb
@@ -1,0 +1,13 @@
+module JavaClass
+  def method_missing(meth, *args, &block)
+    if block
+      eval <<-RUBY_CODE
+        define_method(#{meth}) do |#{args.join(',')}|
+        #{block.call}
+      end
+      RUBY_CODE
+    else
+      meth
+    end
+  end
+end

--- a/lib/java/type.rb
+++ b/lib/java/type.rb
@@ -16,9 +16,10 @@ class Type
 
   class << self
     def define_new(sym, klass, &condition)
+      type = find_or_create(sym, klass, &condition)
       Module.class_eval do
         define_method(sym) do |meth|
-          define_typed_method(meth, Type.find_or_create(sym, klass, &condition))
+          define_typed_method(meth, type)
         end
         private sym
       end
@@ -30,6 +31,10 @@ class Type
 
     def find_or_create(sym, klass, &condition)
       find(sym) || new(sym, klass, &condition)
+    end
+
+    def types
+      @@types
     end
   end
 end

--- a/test/java_test.rb
+++ b/test/java_test.rb
@@ -96,10 +96,10 @@ class JavaTest < Minitest::Test
 
   private
     def define_test_method(type, val)
-      klass = Class.new.class_eval <<-RUBY_CODE
-        public #{type} def call
+      klass = Class.new.extend(JavaClass).class_eval <<-RUBY_CODE
+        public #{type} call(){"
           ObjectSpace._id2ref(#{val.__id__})
-        end
+        "}
       RUBY_CODE
 
       klass.new


### PR DESCRIPTION
I'm aiming to https://gist.github.com/chancancode/61f31ac0b508c8eccad7

Right now, we can write as below.

```
require 'java'
class MyClass
  extend JavaClass

  public int my_method(arg1, arg2) {"
    ...
  "}
end
```
